### PR TITLE
fix inference error by using torch==2.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ sentence-transformers==3.0.1
 sentencepiece==0.2.0
 tensorboard==2.17.0
 tokenizers==0.19.1
-torch==2.3.1
+torch==2.4.0
 torchaudio==2.3.1
 torchvision==0.18.1
 tqdm==4.66.4


### PR DESCRIPTION
fix inference error by using `torch==2.4.0`:

```
  File "/data/bodhihu/scattermoe/scattermoe/kernels/ops.py", line 9, in <module>
    @torch.library.custom_op("scattermoe::bincount", mutates_args={})
     ^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'torch.library' has no attribute 'custom_op'
```